### PR TITLE
Update linter.py

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -9,7 +9,7 @@ class Tslint(NodeLinter):
     cmd = 'tslint ${file}'
     npm_name = 'tslint'
     regex = (
-        r'^(?:(?P<error>ERROR)|(?P<warning>WARNING))'
+        r'^(?:(?P<error>ERROR)|(?P<warning>WARNING))?'
         r'.+?\[(?P<line>\d+), (?P<col>\d+)\]: '
         r'(?P<message>.+)'
     )


### PR DESCRIPTION
Make Severity optional, as it is not shown by all versions of tslint