### PR TITLE
Parse rule name from verbose format

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -6,12 +6,12 @@ logger = logging.getLogger('SublimeLinter.plugin.tslint')
 
 
 class Tslint(NodeLinter):
-    cmd = 'tslint ${file}'
+    cmd = 'tslint --format verbose ${file}'
     npm_name = 'tslint'
     regex = (
         r'^(?:'
-          r'(ERROR:\s+\((?P<error>.*)\))|'
-          r'(WARNING:\s+\((?P<warning>.*)\))'
+        r'(ERROR:\s+\((?P<error>.*)\))|'
+        r'(WARNING:\s+\((?P<warning>.*)\))'
         r')?'
         r'.+?\[(?P<line>\d+), (?P<col>\d+)\]: '
         r'(?P<message>.+)'

--- a/linter.py
+++ b/linter.py
@@ -9,7 +9,10 @@ class Tslint(NodeLinter):
     cmd = 'tslint ${file}'
     npm_name = 'tslint'
     regex = (
-        r'^(?:(?P<error>ERROR)|(?P<warning>WARNING))?'
+        r'^(?:'
+          r'(ERROR:\s+\((?P<error>.*)\))|'
+          r'(WARNING:\s+\((?P<warning>.*)\))'
+        r')?'
         r'.+?\[(?P<line>\d+), (?P<col>\d+)\]: '
         r'(?P<message>.+)'
     )


### PR DESCRIPTION
Hi!

I've just checked changes with default `prose` formatter and see that it shows `error` severity for warnings. Support for both formatters will make regexp more complex. Maybe it should be better suggested using verbose formatter in readme?