### PR TITLE
Resolve depreciation warning.

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -7,7 +7,6 @@ logger = logging.getLogger('SublimeLinter.plugin.tslint')
 
 class Tslint(NodeLinter):
     cmd = 'tslint --format verbose ${file}'
-    npm_name = 'tslint'
     regex = (
         r'^(?:'
         r'(ERROR:\s+\((?P<error>.*)\))|'


### PR DESCRIPTION
Resolve SublimeLinter warning:

> SublimeLinter: WARNING: tslint: Defining 'cls.npm_name' has no effect. Please cleanup and remove these settings.