### PR TITLE
Update regex to include filename capture group.

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -12,7 +12,8 @@ class Tslint(NodeLinter):
         r'(ERROR:\s+\((?P<error>.*)\))|'
         r'(WARNING:\s+\((?P<warning>.*)\))'
         r')?'
-        r'.+?\[(?P<line>\d+), (?P<col>\d+)\]: '
+        r'\s+(?P<filename>.+?)'
+        r'\[(?P<line>\d+), (?P<col>\d+)\]: '
         r'(?P<message>.+)'
     )
     tempfile_suffix = '-'


### PR DESCRIPTION
I'm using some [Codelyzer](http://codelyzer.com/rules/) (plugin for tslint) template rules that reference the template files in the errors. Given SublimeLinter's new support for multi-file linters I've updated the regex here to support this style.